### PR TITLE
Email update even for no action needed

### DIFF
--- a/bin/notify_updates.sh
+++ b/bin/notify_updates.sh
@@ -3,8 +3,10 @@
 report_email=$(awk -F= '/email/ { print $2 }' ../config.txt)
 record_file=$(awk -F= '/recordFile/ { print $2 }' ../config.txt)
 
-if [ -n "$record_file" ]; then
-    mutt -s "WordPress Updates Needed" "$report_email" < "$record_file"
+if [[ -s "$record_file" ]]; then
+    mutt -s "wp-update-scanner: WordPress Updates Needed" "$report_email" < "$record_file"
+else
+    echo "Scan complete. No updates needed." | mutt -s "wp-update-scanner: No updates" "$report_email"
 fi
 
 exit


### PR DESCRIPTION
I changed the path to where this script runs for me and stopped getting notified. Then it occurred to me that it had been a while since I've had to update anything. Surprise! It hasn't been running for weeks. I opted to have an email sent every time it runs no matter what. I'm more likely to notice it this way vs setting up and checking system logs - although that may be something I should set up anyway.